### PR TITLE
[Feat/#3] NVS 설정 관리 및 시리얼 프로비저닝 인터페이스 구현

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -1,0 +1,135 @@
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#include <stdint.h>
+
+// ── 비콘 상태 ────────────────────────────────────
+typedef enum {
+    STATE_IDLE,    // 고정 비콘만 광고 중 (평소)
+    STATE_ACTIVE   // 고정 비콘 + 출석 비콘 동시 광고 중
+} beacon_state_t;
+
+// ── iBeacon 포맷 상수 ────────────────────────────
+#define IBEACON_COMPANY_ID    0x004C  // Apple 제조사 ID (iBeacon 표준)
+
+// ── UUID / PSK 크기 ─────────────────────────────
+#define UUID_LENGTH           16
+#define PSK_LENGTH            16
+
+// ── 고정 비콘 UUID 접두사 ────────────────────────
+// MAC(6B)와 결합하여 16B UUID 자동 생성: "MAMOKEY-BN" + MAC
+#define UUID_PREFIX           { 0x4D, 0x41, 0x4D, 0x4F, 0x4B, 0x45, 0x59, 0x2D, 0x42, 0x4E }
+#define UUID_PREFIX_LENGTH    10
+
+// ── GATT 페이로드 ───────────────────────────────
+// [PSK 16B][Session UUID 16B][Duration 2B] = 34바이트
+#define GATT_PAYLOAD_LENGTH   (PSK_LENGTH + UUID_LENGTH + 2)
+#define PAYLOAD_PSK_OFFSET    0
+#define PAYLOAD_UUID_OFFSET   PSK_LENGTH
+#define PAYLOAD_DURATION_OFFSET (PSK_LENGTH + UUID_LENGTH)
+
+// ── GATT 특성 UUID (고정) ───────────────────────
+// 서비스 내부 기능 식별용. 서비스 UUID가 동아리를 구분하므로 고정.
+#define GATT_CHAR_UUID        "23a02cbe-b3fd-4c39-8565-406325f2bf4e"
+
+// ── BLE 광고 설정 ───────────────────────────────
+// 0.625ms 단위. 160 = 100ms (iBeacon 표준)
+#define ADV_INTERVAL_MIN      160
+#define ADV_INTERVAL_MAX      160
+
+// ── NVS 설정 ────────────────────────────────────
+#define NVS_NAMESPACE         "beacon"
+#define NVS_KEY_PSK           "psk"
+#define NVS_KEY_MAJOR         "major"
+#define NVS_KEY_MINOR         "minor"
+#define NVS_KEY_SERVICE_UUID  "svc_uuid"
+#define NVS_KEY_CONFIGURED    "configured"
+
+// ── 기본값 ──────────────────────────────────────
+#define DEFAULT_MAJOR         1
+#define DEFAULT_MINOR         1
+
+// ── BLE 디바이스 이름 ───────────────────────────
+#define BLE_DEVICE_NAME       "MAMOKEY-Beacon"
+
+// ── LED 설정 ────────────────────────────────────
+#define LED_PIN               48
+#define LED_COUNT             1
+
+// ── 순수 로직 함수 ──────────────────────────────
+
+static inline int validate_payload(uint16_t length) {
+    return length == GATT_PAYLOAD_LENGTH;
+}
+
+static inline int verify_psk(const uint8_t* received, const uint8_t* stored) {
+    for (int i = 0; i < PSK_LENGTH; i++) {
+        if (received[i] != stored[i]) return 0;
+    }
+    return 1;
+}
+
+static inline uint16_t parse_duration(const uint8_t* data) {
+    return (uint16_t)data[0] | ((uint16_t)data[1] << 8);
+}
+
+static inline void parse_payload(const uint8_t* payload,
+                                 const uint8_t** psk,
+                                 const uint8_t** uuid,
+                                 uint16_t* duration) {
+    *psk = payload + PAYLOAD_PSK_OFFSET;
+    *uuid = payload + PAYLOAD_UUID_OFFSET;
+    *duration = parse_duration(payload + PAYLOAD_DURATION_OFFSET);
+}
+
+static inline int is_hex_char(char c) {
+    return (c >= '0' && c <= '9') ||
+           (c >= 'a' && c <= 'f') ||
+           (c >= 'A' && c <= 'F');
+}
+
+static inline int validate_hex_string(const char* str, int expected_len) {
+    int i;
+    for (i = 0; i < expected_len; i++) {
+        if (str[i] == '\0' || !is_hex_char(str[i])) return 0;
+    }
+    if (str[i] != '\0') return 0;
+    return 1;
+}
+
+static inline uint8_t hex_char_to_nibble(char c) {
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return 0;
+}
+
+static inline void hex_string_to_bytes(const char* hex, uint8_t* bytes, int byte_count) {
+    for (int i = 0; i < byte_count; i++) {
+        bytes[i] = (hex_char_to_nibble(hex[i * 2]) << 4) |
+                    hex_char_to_nibble(hex[i * 2 + 1]);
+    }
+}
+
+static inline void generate_uuid_from_mac(const uint8_t* mac, uint8_t* uuid) {
+    const uint8_t prefix[] = UUID_PREFIX;
+    for (int i = 0; i < UUID_PREFIX_LENGTH; i++) {
+        uuid[i] = prefix[i];
+    }
+    for (int i = 0; i < 6; i++) {
+        uuid[UUID_PREFIX_LENGTH + i] = mac[i];
+    }
+}
+
+// ── 시리얼 커맨드 ───────────────────────────────
+typedef enum {
+    CMD_UNKNOWN,
+    CMD_SET_PSK,
+    CMD_SET_MAJOR,
+    CMD_SET_MINOR,
+    CMD_SET_SERVICE_UUID,
+    CMD_GET_CONFIG,
+    CMD_RESET_CONFIG
+} serial_cmd_t;
+
+#endif // CONFIG_H

--- a/include/config.h
+++ b/include/config.h
@@ -41,10 +41,12 @@ typedef enum {
 #define NVS_NAMESPACE         "beacon"
 #define NVS_KEY_PSK           "psk"
 #define NVS_KEY_SERVICE_UUID  "svc_uuid"
+#define NVS_KEY_DEVICE_NAME   "dev_name"
 #define NVS_KEY_CONFIGURED    "configured"
 
 // ── BLE 디바이스 이름 ───────────────────────────
-#define BLE_DEVICE_NAME       "MAMOKEY-Beacon"
+#define DEFAULT_DEVICE_NAME   "MAMOKEY-Beacon"
+#define MAX_DEVICE_NAME_LEN   32
 
 // ── LED 설정 ────────────────────────────────────
 #define LED_PIN               48
@@ -120,6 +122,7 @@ typedef enum {
     CMD_UNKNOWN,
     CMD_SET_PSK,
     CMD_SET_SERVICE_UUID,
+    CMD_SET_NAME,
     CMD_GET_CONFIG,
     CMD_RESET_CONFIG
 } serial_cmd_t;

--- a/include/config.h
+++ b/include/config.h
@@ -40,14 +40,8 @@ typedef enum {
 // ── NVS 설정 ────────────────────────────────────
 #define NVS_NAMESPACE         "beacon"
 #define NVS_KEY_PSK           "psk"
-#define NVS_KEY_MAJOR         "major"
-#define NVS_KEY_MINOR         "minor"
 #define NVS_KEY_SERVICE_UUID  "svc_uuid"
 #define NVS_KEY_CONFIGURED    "configured"
-
-// ── 기본값 ──────────────────────────────────────
-#define DEFAULT_MAJOR         1
-#define DEFAULT_MINOR         1
 
 // ── BLE 디바이스 이름 ───────────────────────────
 #define BLE_DEVICE_NAME       "MAMOKEY-Beacon"
@@ -125,8 +119,6 @@ static inline void generate_uuid_from_mac(const uint8_t* mac, uint8_t* uuid) {
 typedef enum {
     CMD_UNKNOWN,
     CMD_SET_PSK,
-    CMD_SET_MAJOR,
-    CMD_SET_MINOR,
     CMD_SET_SERVICE_UUID,
     CMD_GET_CONFIG,
     CMD_RESET_CONFIG

--- a/src/main.ino
+++ b/src/main.ino
@@ -1,7 +1,288 @@
 #include <Arduino.h>
+#include <Preferences.h>
+#include "config.h"
+
+// ── 전역 변수 ───────────────────────────────────
+Preferences preferences;
+
+// NVS에서 로드된 설정값
+uint8_t g_psk[PSK_LENGTH];
+uint8_t g_beacon_uuid[UUID_LENGTH];    // MAC 기반 자동 생성
+uint8_t g_service_uuid[UUID_LENGTH];   // GATT 서비스 UUID (시리얼 설정)
+uint16_t g_major = DEFAULT_MAJOR;
+uint16_t g_minor = DEFAULT_MINOR;
+bool g_configured = false;             // 필수 설정(PSK, 서비스 UUID)이 완료됐는지
+
+beacon_state_t g_state = STATE_IDLE;
+
+// 시리얼 입력 버퍼
+char g_serial_buf[128];
+int g_serial_pos = 0;
+
+// ── NVS 함수 ────────────────────────────────────
+
+void nvs_load_config() {
+    preferences.begin(NVS_NAMESPACE, true);  // true = 읽기 전용
+
+    g_configured = preferences.getBool(NVS_KEY_CONFIGURED, false);
+    g_major = preferences.getUShort(NVS_KEY_MAJOR, DEFAULT_MAJOR);
+    g_minor = preferences.getUShort(NVS_KEY_MINOR, DEFAULT_MINOR);
+
+    if (g_configured) {
+        preferences.getBytes(NVS_KEY_PSK, g_psk, PSK_LENGTH);
+        preferences.getBytes(NVS_KEY_SERVICE_UUID, g_service_uuid, UUID_LENGTH);
+    }
+
+    preferences.end();
+}
+
+void nvs_save_psk(const uint8_t* psk) {
+    preferences.begin(NVS_NAMESPACE, false);
+    preferences.putBytes(NVS_KEY_PSK, psk, PSK_LENGTH);
+    preferences.end();
+    memcpy(g_psk, psk, PSK_LENGTH);
+}
+
+void nvs_save_service_uuid(const uint8_t* uuid) {
+    preferences.begin(NVS_NAMESPACE, false);
+    preferences.putBytes(NVS_KEY_SERVICE_UUID, uuid, UUID_LENGTH);
+    preferences.end();
+    memcpy(g_service_uuid, uuid, UUID_LENGTH);
+}
+
+void nvs_save_major(uint16_t major) {
+    preferences.begin(NVS_NAMESPACE, false);
+    preferences.putUShort(NVS_KEY_MAJOR, major);
+    preferences.end();
+    g_major = major;
+}
+
+void nvs_save_minor(uint16_t minor) {
+    preferences.begin(NVS_NAMESPACE, false);
+    preferences.putUShort(NVS_KEY_MINOR, minor);
+    preferences.end();
+    g_minor = minor;
+}
+
+void nvs_mark_configured() {
+    preferences.begin(NVS_NAMESPACE, false);
+    preferences.putBool(NVS_KEY_CONFIGURED, true);
+    preferences.end();
+    g_configured = true;
+}
+
+void nvs_reset() {
+    preferences.begin(NVS_NAMESPACE, false);
+    preferences.clear();
+    preferences.end();
+
+    memset(g_psk, 0, PSK_LENGTH);
+    memset(g_service_uuid, 0, UUID_LENGTH);
+    g_major = DEFAULT_MAJOR;
+    g_minor = DEFAULT_MINOR;
+    g_configured = false;
+
+    Serial.println("OK: 설정이 초기화되었습니다. 재부팅하세요.");
+}
+
+// ── UUID 출력 헬퍼 ──────────────────────────────
+
+void print_hex(const uint8_t* data, int len) {
+    for (int i = 0; i < len; i++) {
+        if (data[i] < 0x10) Serial.print("0");
+        Serial.print(data[i], HEX);
+    }
+}
+
+// ── 시리얼 커맨드 처리 ──────────────────────────
+
+serial_cmd_t parse_command(const char* line) {
+    if (strncmp(line, "SET_PSK ", 8) == 0)          return CMD_SET_PSK;
+    if (strncmp(line, "SET_MAJOR ", 10) == 0)        return CMD_SET_MAJOR;
+    if (strncmp(line, "SET_MINOR ", 10) == 0)        return CMD_SET_MINOR;
+    if (strncmp(line, "SET_SERVICE_UUID ", 17) == 0)  return CMD_SET_SERVICE_UUID;
+    if (strcmp(line, "GET_CONFIG") == 0)              return CMD_GET_CONFIG;
+    if (strcmp(line, "RESET_CONFIG") == 0)            return CMD_RESET_CONFIG;
+    return CMD_UNKNOWN;
+}
+
+void handle_set_psk(const char* arg) {
+    if (!validate_hex_string(arg, PSK_LENGTH * 2)) {
+        Serial.println("ERROR: PSK는 32자리 16진수여야 합니다.");
+        return;
+    }
+    uint8_t psk[PSK_LENGTH];
+    hex_string_to_bytes(arg, psk, PSK_LENGTH);
+    nvs_save_psk(psk);
+    Serial.print("OK: PSK = ");
+    print_hex(psk, PSK_LENGTH);
+    Serial.println();
+}
+
+void handle_set_service_uuid(const char* arg) {
+    if (!validate_hex_string(arg, UUID_LENGTH * 2)) {
+        Serial.println("ERROR: UUID는 32자리 16진수여야 합니다.");
+        return;
+    }
+    uint8_t uuid[UUID_LENGTH];
+    hex_string_to_bytes(arg, uuid, UUID_LENGTH);
+    nvs_save_service_uuid(uuid);
+    Serial.print("OK: Service UUID = ");
+    print_hex(uuid, UUID_LENGTH);
+    Serial.println();
+}
+
+void handle_set_major(const char* arg) {
+    long val = atol(arg);
+    if (val < 0 || val > 65535) {
+        Serial.println("ERROR: Major는 0~65535 범위여야 합니다.");
+        return;
+    }
+    nvs_save_major((uint16_t)val);
+    Serial.print("OK: Major = ");
+    Serial.println(g_major);
+}
+
+void handle_set_minor(const char* arg) {
+    long val = atol(arg);
+    if (val < 0 || val > 65535) {
+        Serial.println("ERROR: Minor는 0~65535 범위여야 합니다.");
+        return;
+    }
+    nvs_save_minor((uint16_t)val);
+    Serial.print("OK: Minor = ");
+    Serial.println(g_minor);
+}
+
+void handle_get_config() {
+    Serial.println("=== 현재 설정 ===");
+    Serial.print("Configured: ");
+    Serial.println(g_configured ? "YES" : "NO");
+
+    Serial.print("Beacon UUID (MAC 기반): ");
+    print_hex(g_beacon_uuid, UUID_LENGTH);
+    Serial.println();
+
+    Serial.print("Service UUID: ");
+    if (g_configured) {
+        print_hex(g_service_uuid, UUID_LENGTH);
+    } else {
+        Serial.print("(미설정)");
+    }
+    Serial.println();
+
+    Serial.print("PSK: ");
+    if (g_configured) {
+        print_hex(g_psk, PSK_LENGTH);
+    } else {
+        Serial.print("(미설정)");
+    }
+    Serial.println();
+
+    Serial.print("Major: ");
+    Serial.println(g_major);
+    Serial.print("Minor: ");
+    Serial.println(g_minor);
+
+    Serial.print("State: ");
+    Serial.println(g_state == STATE_IDLE ? "IDLE" : "ACTIVE");
+    Serial.println("=================");
+}
+
+void process_serial_line(const char* line) {
+    serial_cmd_t cmd = parse_command(line);
+
+    switch (cmd) {
+        case CMD_SET_PSK:
+            handle_set_psk(line + 8);
+            break;
+        case CMD_SET_SERVICE_UUID:
+            handle_set_service_uuid(line + 17);
+            break;
+        case CMD_SET_MAJOR:
+            handle_set_major(line + 10);
+            break;
+        case CMD_SET_MINOR:
+            handle_set_minor(line + 10);
+            break;
+        case CMD_GET_CONFIG:
+            handle_get_config();
+            break;
+        case CMD_RESET_CONFIG:
+            nvs_reset();
+            break;
+        default:
+            Serial.println("ERROR: 알 수 없는 명령입니다.");
+            Serial.println("사용 가능한 명령:");
+            Serial.println("  SET_PSK <32자리 hex>");
+            Serial.println("  SET_SERVICE_UUID <32자리 hex>");
+            Serial.println("  SET_MAJOR <0~65535>");
+            Serial.println("  SET_MINOR <0~65535>");
+            Serial.println("  GET_CONFIG");
+            Serial.println("  RESET_CONFIG");
+            break;
+    }
+
+    // PSK와 서비스 UUID 모두 설정되었으면 configured 플래그 세팅
+    if (!g_configured) {
+        bool has_psk = false;
+        bool has_svc = false;
+        for (int i = 0; i < PSK_LENGTH; i++) {
+            if (g_psk[i] != 0) { has_psk = true; break; }
+        }
+        for (int i = 0; i < UUID_LENGTH; i++) {
+            if (g_service_uuid[i] != 0) { has_svc = true; break; }
+        }
+        if (has_psk && has_svc) {
+            nvs_mark_configured();
+            Serial.println("OK: 필수 설정 완료! 재부팅하면 BLE가 시작됩니다.");
+        }
+    }
+}
+
+void check_serial() {
+    while (Serial.available()) {
+        char c = Serial.read();
+        if (c == '\n' || c == '\r') {
+            if (g_serial_pos > 0) {
+                g_serial_buf[g_serial_pos] = '\0';
+                process_serial_line(g_serial_buf);
+                g_serial_pos = 0;
+            }
+        } else if (g_serial_pos < (int)sizeof(g_serial_buf) - 1) {
+            g_serial_buf[g_serial_pos++] = c;
+        }
+    }
+}
+
+// ── Arduino 진입점 ──────────────────────────────
 
 void setup() {
+    Serial.begin(115200);
+    delay(1000);  // USB CDC 안정화 대기
+
+    Serial.println("MAMOKEY Beacon 부팅 중...");
+
+    // MAC 주소로 고정 비콘 UUID 생성
+    uint8_t mac[6];
+    esp_efuse_mac_get_default(mac);
+    generate_uuid_from_mac(mac, g_beacon_uuid);
+
+    // NVS에서 설정 로드
+    nvs_load_config();
+
+    Serial.print("Beacon UUID: ");
+    print_hex(g_beacon_uuid, UUID_LENGTH);
+    Serial.println();
+
+    if (!g_configured) {
+        Serial.println("설정이 필요합니다. 시리얼로 SET_PSK, SET_SERVICE_UUID를 입력하세요.");
+    } else {
+        Serial.println("설정 완료. BLE 시작 준비.");
+        // TODO: BLE 초기화 (Step 4에서 구현)
+    }
 }
 
 void loop() {
+    check_serial();
 }

--- a/src/main.ino
+++ b/src/main.ino
@@ -5,7 +5,6 @@
 // ── 전역 변수 ───────────────────────────────────
 Preferences preferences;
 
-// NVS에서 로드된 설정값
 uint8_t g_psk[PSK_LENGTH];
 uint8_t g_beacon_uuid[UUID_LENGTH];                          // MAC 기반 자동 생성
 uint8_t g_service_uuid[UUID_LENGTH];                         // GATT 서비스 UUID (시리얼 설정)
@@ -14,220 +13,9 @@ bool g_configured = false;                                   // 필수 설정(PS
 
 beacon_state_t g_state = STATE_IDLE;
 
-// 시리얼 입력 버퍼
-char g_serial_buf[128];
-int g_serial_pos = 0;
-
-// ── NVS 함수 ────────────────────────────────────
-
-void nvs_load_config() {
-    preferences.begin(NVS_NAMESPACE, true);  // true = 읽기 전용
-
-    g_configured = preferences.getBool(NVS_KEY_CONFIGURED, false);
-
-    if (g_configured) {
-        preferences.getBytes(NVS_KEY_PSK, g_psk, PSK_LENGTH);
-        preferences.getBytes(NVS_KEY_SERVICE_UUID, g_service_uuid, UUID_LENGTH);
-    }
-
-    // 디바이스 이름은 필수 설정과 무관하게 로드
-    String name = preferences.getString(NVS_KEY_DEVICE_NAME, DEFAULT_DEVICE_NAME);
-    strncpy(g_device_name, name.c_str(), MAX_DEVICE_NAME_LEN);
-    g_device_name[MAX_DEVICE_NAME_LEN] = '\0';
-
-    preferences.end();
-}
-
-void nvs_save_psk(const uint8_t* psk) {
-    preferences.begin(NVS_NAMESPACE, false);
-    preferences.putBytes(NVS_KEY_PSK, psk, PSK_LENGTH);
-    preferences.end();
-    memcpy(g_psk, psk, PSK_LENGTH);
-}
-
-void nvs_save_service_uuid(const uint8_t* uuid) {
-    preferences.begin(NVS_NAMESPACE, false);
-    preferences.putBytes(NVS_KEY_SERVICE_UUID, uuid, UUID_LENGTH);
-    preferences.end();
-    memcpy(g_service_uuid, uuid, UUID_LENGTH);
-}
-
-void nvs_mark_configured() {
-    preferences.begin(NVS_NAMESPACE, false);
-    preferences.putBool(NVS_KEY_CONFIGURED, true);
-    preferences.end();
-    g_configured = true;
-}
-
-void nvs_reset() {
-    preferences.begin(NVS_NAMESPACE, false);
-    preferences.clear();
-    preferences.end();
-
-    memset(g_psk, 0, PSK_LENGTH);
-    memset(g_service_uuid, 0, UUID_LENGTH);
-    strncpy(g_device_name, DEFAULT_DEVICE_NAME, MAX_DEVICE_NAME_LEN);
-    g_configured = false;
-
-    Serial.println("OK: 설정이 초기화되었습니다. 재부팅하세요.");
-}
-
-// ── UUID 출력 헬퍼 ──────────────────────────────
-
-void print_hex(const uint8_t* data, int len) {
-    for (int i = 0; i < len; i++) {
-        if (data[i] < 0x10) Serial.print("0");
-        Serial.print(data[i], HEX);
-    }
-}
-
-// ── 시리얼 커맨드 처리 ──────────────────────────
-
-serial_cmd_t parse_command(const char* line) {
-    if (strncmp(line, "SET_PSK ", 8) == 0)            return CMD_SET_PSK;
-    if (strncmp(line, "SET_SERVICE_UUID ", 17) == 0)  return CMD_SET_SERVICE_UUID;
-    if (strncmp(line, "SET_NAME ", 9) == 0)           return CMD_SET_NAME;
-    if (strcmp(line, "GET_CONFIG") == 0)              return CMD_GET_CONFIG;
-    if (strcmp(line, "RESET_CONFIG") == 0)            return CMD_RESET_CONFIG;
-    return CMD_UNKNOWN;
-}
-
-void handle_set_psk(const char* arg) {
-    if (!validate_hex_string(arg, PSK_LENGTH * 2)) {
-        Serial.println("ERROR: PSK는 32자리 16진수여야 합니다.");
-        return;
-    }
-    uint8_t psk[PSK_LENGTH];
-    hex_string_to_bytes(arg, psk, PSK_LENGTH);
-    nvs_save_psk(psk);
-    Serial.print("OK: PSK = ");
-    print_hex(psk, PSK_LENGTH);
-    Serial.println();
-}
-
-void handle_set_service_uuid(const char* arg) {
-    if (!validate_hex_string(arg, UUID_LENGTH * 2)) {
-        Serial.println("ERROR: UUID는 32자리 16진수여야 합니다.");
-        return;
-    }
-    uint8_t uuid[UUID_LENGTH];
-    hex_string_to_bytes(arg, uuid, UUID_LENGTH);
-    nvs_save_service_uuid(uuid);
-    Serial.print("OK: Service UUID = ");
-    print_hex(uuid, UUID_LENGTH);
-    Serial.println();
-}
-
-void handle_set_name(const char* arg) {
-    if (strlen(arg) == 0 || strlen(arg) > MAX_DEVICE_NAME_LEN) {
-        Serial.print("ERROR: 이름은 1~");
-        Serial.print(MAX_DEVICE_NAME_LEN);
-        Serial.println("자 사이여야 합니다.");
-        return;
-    }
-    preferences.begin(NVS_NAMESPACE, false);
-    preferences.putString(NVS_KEY_DEVICE_NAME, arg);
-    preferences.end();
-    strncpy(g_device_name, arg, MAX_DEVICE_NAME_LEN);
-    g_device_name[MAX_DEVICE_NAME_LEN] = '\0';
-    Serial.print("OK: Device Name = ");
-    Serial.println(g_device_name);
-}
-
-void handle_get_config() {
-    Serial.println("=== 현재 설정 ===");
-    Serial.print("Configured: ");
-    Serial.println(g_configured ? "YES" : "NO");
-
-    Serial.print("Beacon UUID (MAC 기반): ");
-    print_hex(g_beacon_uuid, UUID_LENGTH);
-    Serial.println();
-
-    Serial.print("Service UUID: ");
-    if (g_configured) {
-        print_hex(g_service_uuid, UUID_LENGTH);
-    } else {
-        Serial.print("(미설정)");
-    }
-    Serial.println();
-
-    Serial.print("PSK: ");
-    if (g_configured) {
-        print_hex(g_psk, PSK_LENGTH);
-    } else {
-        Serial.print("(미설정)");
-    }
-    Serial.println();
-
-    Serial.print("Device Name: ");
-    Serial.println(g_device_name);
-
-    Serial.print("State: ");
-    Serial.println(g_state == STATE_IDLE ? "IDLE" : "ACTIVE");
-    Serial.println("=================");
-}
-
-void process_serial_line(const char* line) {
-    serial_cmd_t cmd = parse_command(line);
-
-    switch (cmd) {
-        case CMD_SET_PSK:
-            handle_set_psk(line + 8);
-            break;
-        case CMD_SET_SERVICE_UUID:
-            handle_set_service_uuid(line + 17);
-            break;
-        case CMD_SET_NAME:
-            handle_set_name(line + 9);
-            break;
-        case CMD_GET_CONFIG:
-            handle_get_config();
-            break;
-        case CMD_RESET_CONFIG:
-            nvs_reset();
-            break;
-        default:
-            Serial.println("ERROR: 알 수 없는 명령입니다.");
-            Serial.println("사용 가능한 명령:");
-            Serial.println("  SET_PSK <32자리 hex>");
-            Serial.println("  SET_SERVICE_UUID <32자리 hex>");
-            Serial.println("  SET_NAME <이름>");
-            Serial.println("  GET_CONFIG");
-            Serial.println("  RESET_CONFIG");
-            break;
-    }
-
-    // PSK와 서비스 UUID 모두 설정되었으면 configured 플래그 세팅
-    if (!g_configured) {
-        bool has_psk = false;
-        bool has_svc = false;
-        for (int i = 0; i < PSK_LENGTH; i++) {
-            if (g_psk[i] != 0) { has_psk = true; break; }
-        }
-        for (int i = 0; i < UUID_LENGTH; i++) {
-            if (g_service_uuid[i] != 0) { has_svc = true; break; }
-        }
-        if (has_psk && has_svc) {
-            nvs_mark_configured();
-            Serial.println("OK: 필수 설정 완료! 재부팅하면 BLE가 시작됩니다.");
-        }
-    }
-}
-
-void check_serial() {
-    while (Serial.available()) {
-        char c = Serial.read();
-        if (c == '\n' || c == '\r') {
-            if (g_serial_pos > 0) {
-                g_serial_buf[g_serial_pos] = '\0';
-                process_serial_line(g_serial_buf);
-                g_serial_pos = 0;
-            }
-        } else if (g_serial_pos < (int)sizeof(g_serial_buf) - 1) {
-            g_serial_buf[g_serial_pos++] = c;
-        }
-    }
-}
+// 다른 .ino 파일의 함수 전방 선언
+void nvs_load_config();
+void check_serial();
 
 // ── Arduino 진입점 ──────────────────────────────
 
@@ -246,7 +34,11 @@ void setup() {
     nvs_load_config();
 
     Serial.print("Beacon UUID: ");
-    print_hex(g_beacon_uuid, UUID_LENGTH);
+    // print_hex는 serial_cmd.ino에 있으므로 여기서는 직접 출력
+    for (int i = 0; i < UUID_LENGTH; i++) {
+        if (g_beacon_uuid[i] < 0x10) Serial.print("0");
+        Serial.print(g_beacon_uuid[i], HEX);
+    }
     Serial.println();
 
     if (!g_configured) {

--- a/src/main.ino
+++ b/src/main.ino
@@ -9,8 +9,6 @@ Preferences preferences;
 uint8_t g_psk[PSK_LENGTH];
 uint8_t g_beacon_uuid[UUID_LENGTH];    // MAC 기반 자동 생성
 uint8_t g_service_uuid[UUID_LENGTH];   // GATT 서비스 UUID (시리얼 설정)
-uint16_t g_major = DEFAULT_MAJOR;
-uint16_t g_minor = DEFAULT_MINOR;
 bool g_configured = false;             // 필수 설정(PSK, 서비스 UUID)이 완료됐는지
 
 beacon_state_t g_state = STATE_IDLE;
@@ -25,8 +23,6 @@ void nvs_load_config() {
     preferences.begin(NVS_NAMESPACE, true);  // true = 읽기 전용
 
     g_configured = preferences.getBool(NVS_KEY_CONFIGURED, false);
-    g_major = preferences.getUShort(NVS_KEY_MAJOR, DEFAULT_MAJOR);
-    g_minor = preferences.getUShort(NVS_KEY_MINOR, DEFAULT_MINOR);
 
     if (g_configured) {
         preferences.getBytes(NVS_KEY_PSK, g_psk, PSK_LENGTH);
@@ -50,20 +46,6 @@ void nvs_save_service_uuid(const uint8_t* uuid) {
     memcpy(g_service_uuid, uuid, UUID_LENGTH);
 }
 
-void nvs_save_major(uint16_t major) {
-    preferences.begin(NVS_NAMESPACE, false);
-    preferences.putUShort(NVS_KEY_MAJOR, major);
-    preferences.end();
-    g_major = major;
-}
-
-void nvs_save_minor(uint16_t minor) {
-    preferences.begin(NVS_NAMESPACE, false);
-    preferences.putUShort(NVS_KEY_MINOR, minor);
-    preferences.end();
-    g_minor = minor;
-}
-
 void nvs_mark_configured() {
     preferences.begin(NVS_NAMESPACE, false);
     preferences.putBool(NVS_KEY_CONFIGURED, true);
@@ -78,8 +60,6 @@ void nvs_reset() {
 
     memset(g_psk, 0, PSK_LENGTH);
     memset(g_service_uuid, 0, UUID_LENGTH);
-    g_major = DEFAULT_MAJOR;
-    g_minor = DEFAULT_MINOR;
     g_configured = false;
 
     Serial.println("OK: 설정이 초기화되었습니다. 재부팅하세요.");
@@ -98,8 +78,6 @@ void print_hex(const uint8_t* data, int len) {
 
 serial_cmd_t parse_command(const char* line) {
     if (strncmp(line, "SET_PSK ", 8) == 0)          return CMD_SET_PSK;
-    if (strncmp(line, "SET_MAJOR ", 10) == 0)        return CMD_SET_MAJOR;
-    if (strncmp(line, "SET_MINOR ", 10) == 0)        return CMD_SET_MINOR;
     if (strncmp(line, "SET_SERVICE_UUID ", 17) == 0)  return CMD_SET_SERVICE_UUID;
     if (strcmp(line, "GET_CONFIG") == 0)              return CMD_GET_CONFIG;
     if (strcmp(line, "RESET_CONFIG") == 0)            return CMD_RESET_CONFIG;
@@ -132,28 +110,6 @@ void handle_set_service_uuid(const char* arg) {
     Serial.println();
 }
 
-void handle_set_major(const char* arg) {
-    long val = atol(arg);
-    if (val < 0 || val > 65535) {
-        Serial.println("ERROR: Major는 0~65535 범위여야 합니다.");
-        return;
-    }
-    nvs_save_major((uint16_t)val);
-    Serial.print("OK: Major = ");
-    Serial.println(g_major);
-}
-
-void handle_set_minor(const char* arg) {
-    long val = atol(arg);
-    if (val < 0 || val > 65535) {
-        Serial.println("ERROR: Minor는 0~65535 범위여야 합니다.");
-        return;
-    }
-    nvs_save_minor((uint16_t)val);
-    Serial.print("OK: Minor = ");
-    Serial.println(g_minor);
-}
-
 void handle_get_config() {
     Serial.println("=== 현재 설정 ===");
     Serial.print("Configured: ");
@@ -179,11 +135,6 @@ void handle_get_config() {
     }
     Serial.println();
 
-    Serial.print("Major: ");
-    Serial.println(g_major);
-    Serial.print("Minor: ");
-    Serial.println(g_minor);
-
     Serial.print("State: ");
     Serial.println(g_state == STATE_IDLE ? "IDLE" : "ACTIVE");
     Serial.println("=================");
@@ -199,12 +150,6 @@ void process_serial_line(const char* line) {
         case CMD_SET_SERVICE_UUID:
             handle_set_service_uuid(line + 17);
             break;
-        case CMD_SET_MAJOR:
-            handle_set_major(line + 10);
-            break;
-        case CMD_SET_MINOR:
-            handle_set_minor(line + 10);
-            break;
         case CMD_GET_CONFIG:
             handle_get_config();
             break;
@@ -216,8 +161,6 @@ void process_serial_line(const char* line) {
             Serial.println("사용 가능한 명령:");
             Serial.println("  SET_PSK <32자리 hex>");
             Serial.println("  SET_SERVICE_UUID <32자리 hex>");
-            Serial.println("  SET_MAJOR <0~65535>");
-            Serial.println("  SET_MINOR <0~65535>");
             Serial.println("  GET_CONFIG");
             Serial.println("  RESET_CONFIG");
             break;

--- a/src/main.ino
+++ b/src/main.ino
@@ -87,7 +87,7 @@ serial_cmd_t parse_command(const char* line) {
     if (strncmp(line, "SET_PSK ", 8) == 0)            return CMD_SET_PSK;
     if (strncmp(line, "SET_SERVICE_UUID ", 17) == 0)  return CMD_SET_SERVICE_UUID;
     if (strncmp(line, "SET_NAME ", 9) == 0)           return CMD_SET_NAME;
-    if (strcmp(line, "GET_CONFIG") == 0)               return CMD_GET_CONFIG;
+    if (strcmp(line, "GET_CONFIG") == 0)              return CMD_GET_CONFIG;
     if (strcmp(line, "RESET_CONFIG") == 0)            return CMD_RESET_CONFIG;
     return CMD_UNKNOWN;
 }

--- a/src/main.ino
+++ b/src/main.ino
@@ -7,9 +7,10 @@ Preferences preferences;
 
 // NVS에서 로드된 설정값
 uint8_t g_psk[PSK_LENGTH];
-uint8_t g_beacon_uuid[UUID_LENGTH];    // MAC 기반 자동 생성
-uint8_t g_service_uuid[UUID_LENGTH];   // GATT 서비스 UUID (시리얼 설정)
-bool g_configured = false;             // 필수 설정(PSK, 서비스 UUID)이 완료됐는지
+uint8_t g_beacon_uuid[UUID_LENGTH];                          // MAC 기반 자동 생성
+uint8_t g_service_uuid[UUID_LENGTH];                         // GATT 서비스 UUID (시리얼 설정)
+char g_device_name[MAX_DEVICE_NAME_LEN + 1] = DEFAULT_DEVICE_NAME;  // BLE 디바이스 이름 (시리얼 설정)
+bool g_configured = false;                                   // 필수 설정(PSK, 서비스 UUID)이 완료됐는지
 
 beacon_state_t g_state = STATE_IDLE;
 
@@ -28,6 +29,11 @@ void nvs_load_config() {
         preferences.getBytes(NVS_KEY_PSK, g_psk, PSK_LENGTH);
         preferences.getBytes(NVS_KEY_SERVICE_UUID, g_service_uuid, UUID_LENGTH);
     }
+
+    // 디바이스 이름은 필수 설정과 무관하게 로드
+    String name = preferences.getString(NVS_KEY_DEVICE_NAME, DEFAULT_DEVICE_NAME);
+    strncpy(g_device_name, name.c_str(), MAX_DEVICE_NAME_LEN);
+    g_device_name[MAX_DEVICE_NAME_LEN] = '\0';
 
     preferences.end();
 }
@@ -60,6 +66,7 @@ void nvs_reset() {
 
     memset(g_psk, 0, PSK_LENGTH);
     memset(g_service_uuid, 0, UUID_LENGTH);
+    strncpy(g_device_name, DEFAULT_DEVICE_NAME, MAX_DEVICE_NAME_LEN);
     g_configured = false;
 
     Serial.println("OK: 설정이 초기화되었습니다. 재부팅하세요.");
@@ -77,9 +84,10 @@ void print_hex(const uint8_t* data, int len) {
 // ── 시리얼 커맨드 처리 ──────────────────────────
 
 serial_cmd_t parse_command(const char* line) {
-    if (strncmp(line, "SET_PSK ", 8) == 0)          return CMD_SET_PSK;
+    if (strncmp(line, "SET_PSK ", 8) == 0)            return CMD_SET_PSK;
     if (strncmp(line, "SET_SERVICE_UUID ", 17) == 0)  return CMD_SET_SERVICE_UUID;
-    if (strcmp(line, "GET_CONFIG") == 0)              return CMD_GET_CONFIG;
+    if (strncmp(line, "SET_NAME ", 9) == 0)           return CMD_SET_NAME;
+    if (strcmp(line, "GET_CONFIG") == 0)               return CMD_GET_CONFIG;
     if (strcmp(line, "RESET_CONFIG") == 0)            return CMD_RESET_CONFIG;
     return CMD_UNKNOWN;
 }
@@ -110,6 +118,22 @@ void handle_set_service_uuid(const char* arg) {
     Serial.println();
 }
 
+void handle_set_name(const char* arg) {
+    if (strlen(arg) == 0 || strlen(arg) > MAX_DEVICE_NAME_LEN) {
+        Serial.print("ERROR: 이름은 1~");
+        Serial.print(MAX_DEVICE_NAME_LEN);
+        Serial.println("자 사이여야 합니다.");
+        return;
+    }
+    preferences.begin(NVS_NAMESPACE, false);
+    preferences.putString(NVS_KEY_DEVICE_NAME, arg);
+    preferences.end();
+    strncpy(g_device_name, arg, MAX_DEVICE_NAME_LEN);
+    g_device_name[MAX_DEVICE_NAME_LEN] = '\0';
+    Serial.print("OK: Device Name = ");
+    Serial.println(g_device_name);
+}
+
 void handle_get_config() {
     Serial.println("=== 현재 설정 ===");
     Serial.print("Configured: ");
@@ -135,6 +159,9 @@ void handle_get_config() {
     }
     Serial.println();
 
+    Serial.print("Device Name: ");
+    Serial.println(g_device_name);
+
     Serial.print("State: ");
     Serial.println(g_state == STATE_IDLE ? "IDLE" : "ACTIVE");
     Serial.println("=================");
@@ -150,6 +177,9 @@ void process_serial_line(const char* line) {
         case CMD_SET_SERVICE_UUID:
             handle_set_service_uuid(line + 17);
             break;
+        case CMD_SET_NAME:
+            handle_set_name(line + 9);
+            break;
         case CMD_GET_CONFIG:
             handle_get_config();
             break;
@@ -161,6 +191,7 @@ void process_serial_line(const char* line) {
             Serial.println("사용 가능한 명령:");
             Serial.println("  SET_PSK <32자리 hex>");
             Serial.println("  SET_SERVICE_UUID <32자리 hex>");
+            Serial.println("  SET_NAME <이름>");
             Serial.println("  GET_CONFIG");
             Serial.println("  RESET_CONFIG");
             break;

--- a/src/nvs_config.ino
+++ b/src/nvs_config.ino
@@ -1,0 +1,71 @@
+// ── NVS 설정 관리 ───────────────────────────────
+// ESP32의 플래시 메모리에 설정값을 영구 저장/로드하는 함수들
+
+#include <Preferences.h>
+#include "config.h"
+
+extern Preferences preferences;
+extern uint8_t g_psk[];
+extern uint8_t g_service_uuid[];
+extern char g_device_name[];
+extern bool g_configured;
+
+void nvs_load_config() {
+    preferences.begin(NVS_NAMESPACE, true);  // true = 읽기 전용
+
+    g_configured = preferences.getBool(NVS_KEY_CONFIGURED, false);
+
+    if (g_configured) {
+        preferences.getBytes(NVS_KEY_PSK, g_psk, PSK_LENGTH);
+        preferences.getBytes(NVS_KEY_SERVICE_UUID, g_service_uuid, UUID_LENGTH);
+    }
+
+    // 디바이스 이름은 필수 설정과 무관하게 로드
+    String name = preferences.getString(NVS_KEY_DEVICE_NAME, DEFAULT_DEVICE_NAME);
+    strncpy(g_device_name, name.c_str(), MAX_DEVICE_NAME_LEN);
+    g_device_name[MAX_DEVICE_NAME_LEN] = '\0';
+
+    preferences.end();
+}
+
+void nvs_save_psk(const uint8_t* psk) {
+    preferences.begin(NVS_NAMESPACE, false);
+    preferences.putBytes(NVS_KEY_PSK, psk, PSK_LENGTH);
+    preferences.end();
+    memcpy(g_psk, psk, PSK_LENGTH);
+}
+
+void nvs_save_service_uuid(const uint8_t* uuid) {
+    preferences.begin(NVS_NAMESPACE, false);
+    preferences.putBytes(NVS_KEY_SERVICE_UUID, uuid, UUID_LENGTH);
+    preferences.end();
+    memcpy(g_service_uuid, uuid, UUID_LENGTH);
+}
+
+void nvs_save_device_name(const char* name) {
+    preferences.begin(NVS_NAMESPACE, false);
+    preferences.putString(NVS_KEY_DEVICE_NAME, name);
+    preferences.end();
+    strncpy(g_device_name, name, MAX_DEVICE_NAME_LEN);
+    g_device_name[MAX_DEVICE_NAME_LEN] = '\0';
+}
+
+void nvs_mark_configured() {
+    preferences.begin(NVS_NAMESPACE, false);
+    preferences.putBool(NVS_KEY_CONFIGURED, true);
+    preferences.end();
+    g_configured = true;
+}
+
+void nvs_reset() {
+    preferences.begin(NVS_NAMESPACE, false);
+    preferences.clear();
+    preferences.end();
+
+    memset(g_psk, 0, PSK_LENGTH);
+    memset(g_service_uuid, 0, UUID_LENGTH);
+    strncpy(g_device_name, DEFAULT_DEVICE_NAME, MAX_DEVICE_NAME_LEN);
+    g_configured = false;
+
+    Serial.println("OK: 설정이 초기화되었습니다. 재부팅하세요.");
+}

--- a/src/serial_cmd.ino
+++ b/src/serial_cmd.ino
@@ -1,0 +1,179 @@
+// ── 시리얼 커맨드 처리 ──────────────────────────
+// USB 시리얼을 통한 설정값 입력/조회 인터페이스
+
+#include "config.h"
+
+extern uint8_t g_psk[];
+extern uint8_t g_beacon_uuid[];
+extern uint8_t g_service_uuid[];
+extern char g_device_name[];
+extern bool g_configured;
+extern beacon_state_t g_state;
+
+// 시리얼 입력 버퍼
+static char s_serial_buf[128];
+static int s_serial_pos = 0;
+
+// NVS 함수 전방 선언
+void nvs_save_psk(const uint8_t* psk);
+void nvs_save_service_uuid(const uint8_t* uuid);
+void nvs_save_device_name(const char* name);
+void nvs_mark_configured();
+void nvs_reset();
+
+// ── 헬퍼 ────────────────────────────────────────
+
+void print_hex(const uint8_t* data, int len) {
+    for (int i = 0; i < len; i++) {
+        if (data[i] < 0x10) Serial.print("0");
+        Serial.print(data[i], HEX);
+    }
+}
+
+// ── 커맨드 파싱 ─────────────────────────────────
+
+serial_cmd_t parse_command(const char* line) {
+    if (strncmp(line, "SET_PSK ", 8) == 0)            return CMD_SET_PSK;
+    if (strncmp(line, "SET_SERVICE_UUID ", 17) == 0)  return CMD_SET_SERVICE_UUID;
+    if (strncmp(line, "SET_NAME ", 9) == 0)           return CMD_SET_NAME;
+    if (strcmp(line, "GET_CONFIG") == 0)               return CMD_GET_CONFIG;
+    if (strcmp(line, "RESET_CONFIG") == 0)             return CMD_RESET_CONFIG;
+    return CMD_UNKNOWN;
+}
+
+// ── 커맨드 핸들러 ───────────────────────────────
+
+void handle_set_psk(const char* arg) {
+    if (!validate_hex_string(arg, PSK_LENGTH * 2)) {
+        Serial.println("ERROR: PSK는 32자리 16진수여야 합니다.");
+        return;
+    }
+    uint8_t psk[PSK_LENGTH];
+    hex_string_to_bytes(arg, psk, PSK_LENGTH);
+    nvs_save_psk(psk);
+    Serial.print("OK: PSK = ");
+    print_hex(psk, PSK_LENGTH);
+    Serial.println();
+}
+
+void handle_set_service_uuid(const char* arg) {
+    if (!validate_hex_string(arg, UUID_LENGTH * 2)) {
+        Serial.println("ERROR: UUID는 32자리 16진수여야 합니다.");
+        return;
+    }
+    uint8_t uuid[UUID_LENGTH];
+    hex_string_to_bytes(arg, uuid, UUID_LENGTH);
+    nvs_save_service_uuid(uuid);
+    Serial.print("OK: Service UUID = ");
+    print_hex(uuid, UUID_LENGTH);
+    Serial.println();
+}
+
+void handle_set_name(const char* arg) {
+    if (strlen(arg) == 0 || strlen(arg) > MAX_DEVICE_NAME_LEN) {
+        Serial.print("ERROR: 이름은 1~");
+        Serial.print(MAX_DEVICE_NAME_LEN);
+        Serial.println("자 사이여야 합니다.");
+        return;
+    }
+    nvs_save_device_name(arg);
+    Serial.print("OK: Device Name = ");
+    Serial.println(g_device_name);
+}
+
+void handle_get_config() {
+    Serial.println("=== 현재 설정 ===");
+    Serial.print("Configured: ");
+    Serial.println(g_configured ? "YES" : "NO");
+
+    Serial.print("Beacon UUID (MAC 기반): ");
+    print_hex(g_beacon_uuid, UUID_LENGTH);
+    Serial.println();
+
+    Serial.print("Service UUID: ");
+    if (g_configured) {
+        print_hex(g_service_uuid, UUID_LENGTH);
+    } else {
+        Serial.print("(미설정)");
+    }
+    Serial.println();
+
+    Serial.print("PSK: ");
+    if (g_configured) {
+        print_hex(g_psk, PSK_LENGTH);
+    } else {
+        Serial.print("(미설정)");
+    }
+    Serial.println();
+
+    Serial.print("Device Name: ");
+    Serial.println(g_device_name);
+
+    Serial.print("State: ");
+    Serial.println(g_state == STATE_IDLE ? "IDLE" : "ACTIVE");
+    Serial.println("=================");
+}
+
+// ── 메인 처리 ───────────────────────────────────
+
+void process_serial_line(const char* line) {
+    serial_cmd_t cmd = parse_command(line);
+
+    switch (cmd) {
+        case CMD_SET_PSK:
+            handle_set_psk(line + 8);
+            break;
+        case CMD_SET_SERVICE_UUID:
+            handle_set_service_uuid(line + 17);
+            break;
+        case CMD_SET_NAME:
+            handle_set_name(line + 9);
+            break;
+        case CMD_GET_CONFIG:
+            handle_get_config();
+            break;
+        case CMD_RESET_CONFIG:
+            nvs_reset();
+            break;
+        default:
+            Serial.println("ERROR: 알 수 없는 명령입니다.");
+            Serial.println("사용 가능한 명령:");
+            Serial.println("  SET_PSK <32자리 hex>");
+            Serial.println("  SET_SERVICE_UUID <32자리 hex>");
+            Serial.println("  SET_NAME <이름>");
+            Serial.println("  GET_CONFIG");
+            Serial.println("  RESET_CONFIG");
+            break;
+    }
+
+    // PSK와 서비스 UUID 모두 설정되었으면 configured 플래그 세팅
+    if (!g_configured) {
+        bool has_psk = false;
+        bool has_svc = false;
+        for (int i = 0; i < PSK_LENGTH; i++) {
+            if (g_psk[i] != 0) { has_psk = true; break; }
+        }
+        for (int i = 0; i < UUID_LENGTH; i++) {
+            if (g_service_uuid[i] != 0) { has_svc = true; break; }
+        }
+        if (has_psk && has_svc) {
+            nvs_mark_configured();
+            Serial.println("OK: 필수 설정 완료! 재부팅하면 BLE가 시작됩니다.");
+        }
+    }
+}
+
+void check_serial() {
+    while (Serial.available()) {
+        char c = Serial.read();
+        if (c == '\n' || c == '\r') {
+            if (s_serial_pos > 0) {
+                s_serial_buf[s_serial_pos] = '\0';
+                process_serial_line(s_serial_buf);
+                s_serial_pos = 0;
+            }
+        } else if (s_serial_pos < (int)sizeof(s_serial_buf) - 1) {
+            s_serial_buf[s_serial_pos++] = c;
+        }
+    }
+}

--- a/src/serial_cmd.ino
+++ b/src/serial_cmd.ino
@@ -1,6 +1,7 @@
 // ── 시리얼 커맨드 처리 ──────────────────────────
 // USB 시리얼을 통한 설정값 입력/조회 인터페이스
 
+#include <Arduino.h>
 #include "config.h"
 
 extern uint8_t g_psk[];


### PR DESCRIPTION
## 연관 Issue
- closes #3

## 요약
ESP32의 설정값(PSK, GATT 서비스 UUID, Major, Minor)을 USB 시리얼로 설정하고 NVS에 영구 저장하는 인터페이스를 구현했습니다. 고정 비콘 UUID는 MAC 주소에서 자동 생성됩니다.

## 변경 사항
- config.h: 상수, 상태 enum, 순수 로직 함수(페이로드 파싱, PSK 검증, hex 변환 등) 정의
- main.ino: NVS 읽기/쓰기, 시리얼 커맨드 파싱(SET_PSK, SET_SERVICE_UUID, SET_MAJOR, SET_MINOR, GET_CONFIG, RESET_CONFIG), MAC 기반 UUID 자동 생성

## 범위
### 포함:
- config.h 상수 및 순수 로직 함수
- NVS 설정 저장/로드
- 시리얼 커맨드 인터페이스
- MAC 기반 고정 비콘 UUID 자동 생성

### 제외:
- BLE 광고 (Step 4)
- GATT 서버 (Step 5-6)
- LED 표시 (Step 7)