### PR TITLE
[Feat/#6] RGB LED 상태 표시 구현

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -56,6 +56,15 @@ typedef enum {
 // ── LED 설정 ────────────────────────────────────
 #define LED_PIN               48
 #define LED_COUNT             1
+#define LED_BRIGHTNESS        30   // 0-255 (눈부심 방지)
+
+// LED 상태
+typedef enum {
+    LED_STATE_UNCONFIGURED,  // 노란색 느린 깜빡임
+    LED_STATE_IDLE,          // 파란색 상시 켜짐
+    LED_STATE_ACTIVE,        // 초록색 빠른 깜빡임
+    LED_STATE_ERROR          // 빨간색 상시 켜짐
+} led_state_t;
 
 // ── 순수 로직 함수 ──────────────────────────────
 

--- a/src/ble_beacon.ino
+++ b/src/ble_beacon.ino
@@ -12,6 +12,8 @@ extern beacon_state_t g_state;
 
 // gatt_server.ino 전방 선언
 bool gatt_init();
+// led_status.ino 전방 선언
+void set_led_state(led_state_t state);
 
 NimBLEExtAdvertising* g_pAdvertising = nullptr;
 TimerHandle_t g_sessionTimer = nullptr;
@@ -115,6 +117,7 @@ void stop_session_beacon() {
 
     g_pAdvertising->stop(ADV_INSTANCE_SESSION);
     g_state = STATE_IDLE;
+    set_led_state(LED_STATE_IDLE);
 }
 
 // FreeRTOS 타이머 콜백: 플래그만 세팅하고 loop에서 처리
@@ -155,6 +158,7 @@ void start_session_beacon(const uint8_t* session_uuid, uint16_t duration_sec) {
     if (!g_pAdvertising->start(ADV_INSTANCE_SESSION, 0, 0)) return;
 
     g_state = STATE_ACTIVE;
+    set_led_state(LED_STATE_ACTIVE);
     g_session_duration = duration_sec;
     g_session_started = true;  // loop에서 로그 출력
 

--- a/src/led_status.ino
+++ b/src/led_status.ino
@@ -1,0 +1,83 @@
+// ── RGB LED 상태 표시 ───────────────────────────
+// Adafruit NeoPixel (WS2812, GPIO 48)로 비콘 상태를 색상/패턴으로 표시
+// FreeRTOS 태스크에서 비동기로 동작하여 BLE 로직을 블로킹하지 않음
+
+#include <Arduino.h>
+#include <Adafruit_NeoPixel.h>
+#include "config.h"
+
+static Adafruit_NeoPixel s_pixel(LED_COUNT, LED_PIN, NEO_GRB + NEO_KHZ800);
+static volatile led_state_t s_led_state = LED_STATE_UNCONFIGURED;
+static TaskHandle_t s_ledTaskHandle = nullptr;
+
+// ── 색상 정의 ───────────────────────────────────
+static const uint32_t COLOR_YELLOW = Adafruit_NeoPixel::Color(255, 200, 0);
+static const uint32_t COLOR_BLUE   = Adafruit_NeoPixel::Color(0, 0, 255);
+static const uint32_t COLOR_GREEN  = Adafruit_NeoPixel::Color(0, 255, 0);
+static const uint32_t COLOR_RED    = Adafruit_NeoPixel::Color(255, 0, 0);
+static const uint32_t COLOR_OFF    = Adafruit_NeoPixel::Color(0, 0, 0);
+
+// ── LED 업데이트 태스크 ─────────────────────────
+void led_task(void* pvParameters) {
+    bool blink_on = true;
+    TickType_t last_toggle = xTaskGetTickCount();
+
+    for (;;) {
+        led_state_t state = s_led_state;
+        uint32_t color;
+        uint32_t blink_interval_ms;
+
+        switch (state) {
+            case LED_STATE_UNCONFIGURED:
+                color = COLOR_YELLOW;
+                blink_interval_ms = 1000;  // 느린 깜빡임
+                break;
+            case LED_STATE_IDLE:
+                color = COLOR_BLUE;
+                blink_interval_ms = 0;     // 상시 켜짐
+                break;
+            case LED_STATE_ACTIVE:
+                color = COLOR_GREEN;
+                blink_interval_ms = 250;   // 빠른 깜빡임
+                break;
+            case LED_STATE_ERROR:
+                color = COLOR_RED;
+                blink_interval_ms = 0;     // 상시 켜짐
+                break;
+            default:
+                color = COLOR_OFF;
+                blink_interval_ms = 0;
+                break;
+        }
+
+        if (blink_interval_ms > 0) {
+            TickType_t now = xTaskGetTickCount();
+            if ((now - last_toggle) >= pdMS_TO_TICKS(blink_interval_ms)) {
+                blink_on = !blink_on;
+                last_toggle = now;
+            }
+            s_pixel.setPixelColor(0, blink_on ? color : COLOR_OFF);
+        } else {
+            s_pixel.setPixelColor(0, color);
+            blink_on = true;
+        }
+
+        s_pixel.show();
+        vTaskDelay(pdMS_TO_TICKS(50));  // 50ms 주기로 업데이트
+    }
+}
+
+// ── 외부 인터페이스 ─────────────────────────────
+
+void led_init() {
+    s_pixel.begin();
+    s_pixel.setBrightness(LED_BRIGHTNESS);
+    s_pixel.setPixelColor(0, COLOR_OFF);
+    s_pixel.show();
+
+    xTaskCreate(led_task, "led", 2048, nullptr, 1, &s_ledTaskHandle);
+}
+
+void set_led_state(led_state_t state) {
+    s_led_state = state;
+}

--- a/src/main.ino
+++ b/src/main.ino
@@ -19,6 +19,8 @@ void nvs_load_config();
 void check_serial();
 bool ble_init_and_start();
 void ble_check_events();
+void led_init();
+void set_led_state(led_state_t state);
 
 // ── Arduino 진입점 ──────────────────────────────
 
@@ -27,6 +29,9 @@ void setup() {
     delay(1000);  // USB CDC 안정화 대기
 
     Serial.println("MAMOKEY Beacon 부팅 중...");
+
+    // LED 초기화 (설정대기 상태로 시작)
+    led_init();
 
     // MAC 주소로 고정 비콘 UUID 생성
     uint8_t mac[6];
@@ -46,11 +51,14 @@ void setup() {
 
     if (!g_configured) {
         Serial.println("설정이 필요합니다. 시리얼로 SET_PSK, SET_SERVICE_UUID를 입력하세요.");
+        set_led_state(LED_STATE_UNCONFIGURED);
     } else {
         if (ble_init_and_start()) {
             Serial.println("BLE 초기화 완료.");
+            set_led_state(LED_STATE_IDLE);
         } else {
             Serial.println("ERROR: BLE 초기화 실패.");
+            set_led_state(LED_STATE_ERROR);
         }
     }
 }


### PR DESCRIPTION
## 연관 Issue
- closes #6

## 요약
ESP32-S3-DevKitC-1 내장 RGB LED(WS2812, GPIO 48)를 활용하여 비콘의 현재 상태를 색상과 패턴으로 직관적으로 표시합니다.

## 변경 사항
- led_status.ino 신규 작성: Adafruit NeoPixel 초기화, 상태별 색상/패턴 정의, FreeRTOS 태스크로 비동기 LED 제어
- config.h에 led_state_t enum 및 LED_BRIGHTNESS 상수 추가
- main.ino에서 LED 초기화 및 설정 상태에 따른 LED 상태 설정
- ble_beacon.ino에서 IDLE↔ACTIVE 상태 전환 시 LED 상태 연동

## 범위
### 포함:
- 상태별 LED 색상/패턴 정의 및 구현 (노란색: 설정대기, 파란색: IDLE, 초록색: ACTIVE, 빨간색: 오류)
- 패턴 구현 (상시 켜짐, 느린 깜빡임 1초, 빠른 깜빡임 250ms)
- FreeRTOS 태스크로 LED 업데이트 비동기 처리

### 제외:
- BLE 로직 변경
- 시리얼 인터페이스 변경